### PR TITLE
Support transparency in track color

### DIFF
--- a/seeker/src/main/java/dev/vivvvek/seeker/Seeker.kt
+++ b/seeker/src/main/java/dev/vivvvek/seeker/Seeker.kt
@@ -431,7 +431,15 @@ private fun DrawScope.drawCap(
     when (cap) {
         StrokeCap.Butt -> Unit
         StrokeCap.Round -> {
-            drawCircle(color, center = start, radius = strokeWidth / 2, blendMode = blendMode)
+            drawArc(
+                color = color,
+                startAngle = -90f,
+                sweepAngle = 180f,
+                useCenter = true,
+                topLeft = start - Offset(strokeWidth / 2, strokeWidth / 2),
+                size = Size(strokeWidth, strokeWidth),
+                blendMode = blendMode,
+            )
         }
         StrokeCap.Square -> {
             val offset = Offset(strokeWidth / 2, strokeWidth / 2)


### PR DESCRIPTION
Instead of drawing read ahead and progress on top of the segments with gaps with SrcIn blend mode, the segments are always drawn without gaps, read ahead and progress overlaid with the default SrcOver blend mode, and only then gaps are removed through the Clear blend mode. See #12 for more details on the original problem.