### PR TITLE
fix: use debugImplementation for ui-tooling

### DIFF
--- a/seeker/build.gradle
+++ b/seeker/build.gradle
@@ -50,7 +50,8 @@ dependencies {
 
     implementation 'androidx.compose.material:material:1.5.1'
 
-    implementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
This should fix an issue of PreviewActivity being kept on apps that are using this library
https://issuetracker.google.com/issues/190649014

if you merge this soon, can you make a small release of it?